### PR TITLE
rclone --local-no-check-updated

### DIFF
--- a/tools/cloud-storage-sync/sync.py
+++ b/tools/cloud-storage-sync/sync.py
@@ -44,7 +44,7 @@ def sync(ev):
     c = provider.load()
     credentialArg = """--s3-access-key-id {} --s3-secret-access-key {} --s3-session-token {}""".format(c["AccessKeyId"], c["SecretAccessKey"], c["Token"])
     print("""rclone {} copy {} {} """.format(regionArg, sourceDir, targetDir), flush=True)
-    os.system("""rclone {} {} copy {} {} """.format(regionArg, credentialArg, sourceDir, targetDir))
+    os.system("""rclone {} {} copy {} {} --local-no-check-updated""".format(regionArg, credentialArg, sourceDir, targetDir))
 
 
 if frequency == "forever":


### PR DESCRIPTION
Adds `--local-no-check-updated` to `rclone` call.

Before this we were getting a lot of the following errors when syncing logs for in-progress applications:

> can't copy - source file is being updated (mod time changed from 2020-12-04 14:21:38.605110331 +0000 UTC to 2020-12-04 14:21:38.683 +0000 UTC)

see: https://rclone.org/local/#local-no-check-updated