### PR TITLE
Exit storage sync container

### DIFF
--- a/internal/aws/s3.go
+++ b/internal/aws/s3.go
@@ -38,7 +38,7 @@ func (s *s3Provider) ConfigureHistoryServerStorage() (*cloudstorage.StorageInfo,
 		return nil, err
 	}
 
-	err = writeFile(name, "ABOUT.txt", aboutText)
+	err = writeFile(name, ".ABOUT.txt", aboutText)
 	if err != nil {
 		return nil, err
 	}

--- a/tools/cloud-storage-sync/sync.py
+++ b/tools/cloud-storage-sync/sync.py
@@ -41,8 +41,10 @@ provider = CredentialProvider()
 
 # use "copy", not "sync": don't delete files in target directory
 def sync(ev):
-    filename = ev.name
-    print("""got event for file: {} """.format(filename), flush=True)
+    filename = ""
+    if ev is not None:
+        filename = ev.name
+        print("""got event for file: {} """.format(filename), flush=True)
     c = provider.load()
     credentialArg = """--s3-access-key-id {} --s3-secret-access-key {} --s3-session-token {}""".format(c["AccessKeyId"], c["SecretAccessKey"], c["Token"])
     print("""rclone {} copy {} {} """.format(regionArg, sourceDir, targetDir), flush=True)

--- a/tools/cloud-storage-sync/sync.py
+++ b/tools/cloud-storage-sync/sync.py
@@ -47,8 +47,8 @@ def sync(ev):
         print("""got event for file: {} """.format(filename), flush=True)
     c = provider.load()
     credentialArg = """--s3-access-key-id {} --s3-secret-access-key {} --s3-session-token {}""".format(c["AccessKeyId"], c["SecretAccessKey"], c["Token"])
-    print("""rclone {} copy {} {} """.format(regionArg, sourceDir, targetDir), flush=True)
-    os.system("""rclone {} {} copy {} {} --local-no-check-updated""".format(regionArg, credentialArg, sourceDir, targetDir))
+    print("""rclone --exclude '*.inprogress' {} copy {} {} """.format(regionArg, sourceDir, targetDir), flush=True)
+    os.system("""rclone --exclude '*.inprogress' {} {} copy {} {} --local-no-check-updated""".format(regionArg, credentialArg, sourceDir, targetDir))
     # exit if we got the final spark log file (no .inprogress ending)
     if filename.startswith("spark-") and not filename.endswith(".inprogress"):
         print("will exit", flush=True)

--- a/tools/cloud-storage-sync/sync.py
+++ b/tools/cloud-storage-sync/sync.py
@@ -41,15 +41,21 @@ provider = CredentialProvider()
 
 # use "copy", not "sync": don't delete files in target directory
 def sync(ev):
+    filename = ev.name
+    print("""got event for file: {} """.format(filename), flush=True)
     c = provider.load()
     credentialArg = """--s3-access-key-id {} --s3-secret-access-key {} --s3-session-token {}""".format(c["AccessKeyId"], c["SecretAccessKey"], c["Token"])
     print("""rclone {} copy {} {} """.format(regionArg, sourceDir, targetDir), flush=True)
     os.system("""rclone {} {} copy {} {} --local-no-check-updated""".format(regionArg, credentialArg, sourceDir, targetDir))
+    # exit if we got the final spark log file (no .inprogress ending)
+    if filename.startswith("spark-") and not filename.endswith(".inprogress"):
+        print("will exit", flush=True)
+        exit(0)
 
 
 if frequency == "forever":
     manager = pyinotify.WatchManager()
-    mask = pyinotify.IN_DELETE | pyinotify.IN_MODIFY | pyinotify.IN_CREATE
+    mask = pyinotify.IN_DELETE | pyinotify.IN_MODIFY | pyinotify.IN_CREATE | pyinotify.IN_MOVED_TO
     manager.add_watch(sourceDir, rec=True, mask=mask)
     notifier = pyinotify.Notifier(manager, sync)
     notifier.loop()


### PR DESCRIPTION
- Adds `IN_MOVED_TO` to mask to detect rename events
- `exit 0` when we see a file called `spark-*`, with no `.inprogress` filename ending
- do not sync `*.inprogress` files
- change name of ABOUT.txt to .ABOUT.txt to avoid history server error logs