### PR TITLE
Add application ID label to Wave  Spark Application CR

### DIFF
--- a/controllers/sparkpod_controller.go
+++ b/controllers/sparkpod_controller.go
@@ -31,9 +31,10 @@ const (
 
 	sparkApplicationFinalizerName = OperatorFinalizerName + "/sparkapplication"
 
-	apiVersion           = "wave.spot.io/v1alpha1"
-	sparkApplicationKind = "SparkApplication"
-	waveKindLabel        = "wave.spot.io/kind"
+	apiVersion             = "wave.spot.io/v1alpha1"
+	sparkApplicationKind   = "SparkApplication"
+	waveKindLabel          = "wave.spot.io/kind"
+	waveApplicationIdLabel = "wave.spot.io/application-id"
 
 	requeueAfterTimeout = 10 * time.Second
 	podDeletionTimeout  = 5 * time.Minute
@@ -517,7 +518,8 @@ func (r *SparkPodReconciler) createNewSparkApplicationCr(ctx context.Context, dr
 	cr := &v1alpha1.SparkApplication{}
 
 	cr.Labels = map[string]string{
-		waveKindLabel: sparkApplicationKind, // Facilitates cost calculations
+		waveKindLabel:          sparkApplicationKind, // Facilitates cost calculations
+		waveApplicationIdLabel: applicationId,        // Facilitates cost calculations
 	}
 
 	cr.Name = applicationId

--- a/controllers/sparkpod_controller_test.go
+++ b/controllers/sparkpod_controller_test.go
@@ -250,8 +250,9 @@ func TestReconcile_driver_whenSuccessful(t *testing.T) {
 	createdCr := &v1alpha1.SparkApplication{}
 	err = ctrlClient.Get(ctx, client.ObjectKey{Name: sparkAppId, Namespace: pod.Namespace}, createdCr)
 	require.NoError(t, err)
-	assert.Equal(t, 1, len(createdCr.Labels))
+	assert.Equal(t, 2, len(createdCr.Labels))
 	assert.Equal(t, sparkApplicationKind, createdCr.Labels[waveKindLabel])
+	assert.Equal(t, sparkAppId, createdCr.Labels[waveApplicationIdLabel])
 	assert.Equal(t, sparkAppId, createdCr.Name)
 	assert.Equal(t, pod.Namespace, createdCr.Namespace)
 	// Application name == driver name until we learn otherwise from Spark API


### PR DESCRIPTION
The `wave.spot.io/kind` label allows showback to return aggregated total cost data automatically for a given timeframe.
- For example, given a timeframe we can obtain total cost for each spark applications that ran during the time frame

The added `wave.spot.io/application-id` label will allow showback to return aggregated cost data  for a given timeframe, partitioned by day (hour if time frame is less than day)
- For example, given a timeframe we can obtain total cost partitioned by day (per hour if timeframe less than day) for each spark applications that ran during that timeframe
