### PR TITLE
start storage sync sidecar first

### DIFF
--- a/admission/pods.go
+++ b/admission/pods.go
@@ -97,7 +97,11 @@ func MutatePod(provider cloudstorage.CloudStorageProvider, log logr.Logger, req 
 		}
 	}
 	if !exists {
-		newSpec.Containers = append(newSpec.Containers, storageContainer)
+		// Add storage sidecar container to front of containers list so it gets started first
+		newContainers := make([]corev1.Container, 0)
+		newContainers = append(newContainers, storageContainer)
+		newContainers = append(newContainers, newSpec.Containers...)
+		newSpec.Containers = newContainers
 	}
 
 	// mount shared volume to all

--- a/admission/pods_test.go
+++ b/admission/pods_test.go
@@ -58,6 +58,7 @@ func TestMutateSimplePod(t *testing.T) {
 	newPod, ok := obj.(*(corev1.Pod))
 	assert.True(t, ok)
 	assert.Equal(t, 2, len(newPod.Spec.Containers))
+	assert.Equal(t, "storage-sync", newPod.Spec.Containers[0].Name)
 	assert.Equal(t, ondemandAffinity, newPod.Spec.Affinity)
 	assert.Equal(t, 1, len(newPod.Spec.Volumes))
 	assert.Equal(t, "spark-logs", newPod.Spec.Volumes[0].Name)


### PR DESCRIPTION
Containers in pods get started sequentially according to their order in the containers list. 

We were appending the storage sync container to the end of the list. This meant that it was possible for the driver container to start, and attempt to start executors, before the storage container started and the pod was marked as ready.

The executors would then fail because they were unable to communicate with the driver service, since the pod is only added as a ready endpoint to the service when the pod becomes ready.