### PR TITLE
Fix Spark operator chart name mismatch

### DIFF
--- a/api/v1alpha1/wavecomponent_types.go
+++ b/api/v1alpha1/wavecomponent_types.go
@@ -33,7 +33,7 @@ const (
 
 	SparkHistoryChartName      ChartName = "spark-history-server"
 	EnterpriseGatewayChartName ChartName = "enterprise-gateway"
-	SparkOperatorChartName     ChartName = "sparkoperator"
+	SparkOperatorChartName     ChartName = "spark-operator"
 	WaveIngressChartName       ChartName = "ingress-nginx"
 )
 

--- a/config/samples/v1alpha1_wavecomponent_sparkoperator.yaml
+++ b/config/samples/v1alpha1_wavecomponent_sparkoperator.yaml
@@ -1,13 +1,13 @@
 apiVersion: wave.spot.io/v1alpha1
 kind: WaveComponent
 metadata:
-  name: sparkoperator
+  name: spark-operator
 spec:
   type: helm
-  name: sparkoperator
-  url: http://storage.googleapis.com/kubernetes-charts-incubator
+  name: spark-operator
+  url: https://charts.spot.io
   state: present
-  version: 0.8.4
+  version: 1.0.5
   valuesConfiguration: |
     sparkJobNamespace: spark-jobs
     enableWebhook: true

--- a/install/installer.go
+++ b/install/installer.go
@@ -297,19 +297,13 @@ func (i *HelmInstaller) Delete(chartName string, repository string, version stri
 	}
 
 	getAction := action.NewUninstall(cfg)
-	rel, err := getAction.Run(releaseName)
+	_, err = getAction.Run(releaseName)
 	if err != nil {
 		i.Log.Error(err, "ignoring deletion error")
+	} else {
+		i.Log.Info("removed", "release", releaseName)
 	}
-	//
-	// if err != nil && err != driver.ErrReleaseNotFound {
-	// 	return fmt.Errorf("existing release check failed, %w", err)
-	// } else if rel != nil {
-	// 	i.Log.Info("release already exists")
-	// 	return nil
-	// }
 
-	i.Log.Info("removed", "release", rel.Release.Name)
 	return nil
 }
 

--- a/internal/components/sparkoperator.go
+++ b/internal/components/sparkoperator.go
@@ -18,8 +18,7 @@ import (
 )
 
 const (
-	SparkOperatorChartName   = "sparkoperator"
-	SparkOperatorReleaseName = "wave-sparkoperator"
+	SparkOperatorReleaseName = "wave-spark-operator"
 )
 
 func GetSparkOperatorConditions(config *rest.Config, client client.Client, log logr.Logger) ([]*v1alpha1.WaveComponentCondition, error) {


### PR DESCRIPTION
- the spark operator chart name is now `spark-operator`, and not `sparkoperator`
- fix panic when uninstall action fails