### PR TITLE
Introduced a Mutator interface abstraction

### DIFF
--- a/admission/configmaps_test.go
+++ b/admission/configmaps_test.go
@@ -81,7 +81,7 @@ var (
 
 func TestMutateEmptyCM(t *testing.T) {
 	req := getAdmissionRequest(t, emptyConfigMap)
-	r, err := MutateConfigMap(&util.FakeStorageProvider{}, log, req)
+	r, err := NewConfigMapMutator(log, &util.FakeStorageProvider{}).Mutate(req)
 	assert.NoError(t, err)
 	assert.NotNil(t, r)
 	assert.Equal(t, emptyConfigMap.UID, r.UID)
@@ -92,7 +92,7 @@ func TestMutateEmptyCM(t *testing.T) {
 
 func TestMutateNonsparkCM(t *testing.T) {
 	req := getAdmissionRequest(t, nonsparkConfigMap)
-	r, err := MutateConfigMap(&util.FakeStorageProvider{}, log, req)
+	r, err := NewConfigMapMutator(log, &util.FakeStorageProvider{}).Mutate(req)
 	assert.NoError(t, err)
 	assert.NotNil(t, r)
 	assert.Equal(t, nonsparkConfigMap.UID, r.UID)
@@ -103,7 +103,7 @@ func TestMutateNonsparkCM(t *testing.T) {
 
 func TestMutateBadSparkCM(t *testing.T) {
 	req := getAdmissionRequest(t, badSparkConfigMap)
-	r, err := MutateConfigMap(&util.FakeStorageProvider{}, log, req)
+	r, err := NewConfigMapMutator(log, &util.FakeStorageProvider{}).Mutate(req)
 	assert.NoError(t, err)
 	assert.NotNil(t, r)
 	assert.Equal(t, badSparkConfigMap.UID, r.UID)
@@ -114,7 +114,7 @@ func TestMutateBadSparkCM(t *testing.T) {
 
 func TestMutateSparkCM(t *testing.T) {
 	req := getAdmissionRequest(t, sparkConfigMap)
-	r, err := MutateConfigMap(&util.FakeStorageProvider{}, log, req)
+	r, err := NewConfigMapMutator(log, &util.FakeStorageProvider{}).Mutate(req)
 	assert.NoError(t, err)
 	assert.NotNil(t, r)
 	assert.Equal(t, sparkConfigMap.UID, r.UID)
@@ -130,15 +130,17 @@ func TestMutateSparkCM(t *testing.T) {
 
 func TestMutateSparkBadStorageCM(t *testing.T) {
 	req := getAdmissionRequest(t, sparkConfigMap)
-	r, err := MutateConfigMap(&util.FailedStorageProvider{}, log, req)
+	m := NewConfigMapMutator(log, &util.FailedStorageProvider{})
+	r, err := m.Mutate(req)
 	assert.NoError(t, err)
 	assert.NotNil(t, r)
 	assert.Nil(t, r.PatchType)
 	assert.Nil(t, r.Patch)
 	assert.True(t, r.Allowed)
 
+	m = NewConfigMapMutator(log, &util.NilStorageProvider{})
 	req = getAdmissionRequest(t, sparkConfigMap)
-	r, err = MutateConfigMap(&util.NilStorageProvider{}, log, req)
+	r, err = m.Mutate(req)
 	assert.NoError(t, err)
 	assert.NotNil(t, r)
 	assert.Nil(t, r.PatchType)

--- a/admission/pods_test.go
+++ b/admission/pods_test.go
@@ -138,8 +138,7 @@ func TestMutatePodBadStorage(t *testing.T) {
 		SparkRoleLabel: SparkRoleDriverValue,
 	}
 	req := getAdmissionRequest(t, driverPod)
-	m := NewPodMutator(log, &util.FailedStorageProvider{})
-	r, err := m.Mutate(req)
+	r, err := NewPodMutator(log, &util.FailedStorageProvider{}).Mutate(req)
 	assert.NoError(t, err)
 	assert.NotNil(t, r)
 	assert.Equal(t, driverPod.UID, r.UID)
@@ -148,7 +147,7 @@ func TestMutatePodBadStorage(t *testing.T) {
 	assert.True(t, r.Allowed)
 
 	req = getAdmissionRequest(t, driverPod)
-	r, err = m.Mutate(req)
+	r, err = NewPodMutator(log, &util.NilStorageProvider{}).Mutate(req)
 	assert.NoError(t, err)
 	assert.NotNil(t, r)
 	assert.Equal(t, driverPod.UID, r.UID)

--- a/admission/pods_test.go
+++ b/admission/pods_test.go
@@ -48,7 +48,7 @@ func TestMutateDriverPod(t *testing.T) {
 		SparkRoleLabel: SparkRoleDriverValue,
 	}
 	req := getAdmissionRequest(t, driverPod)
-	r, err := MutatePod(&util.FakeStorageProvider{}, log, req)
+	r, err := NewPodMutator(log, &util.FakeStorageProvider{}).Mutate(req)
 	assert.NoError(t, err)
 	assert.NotNil(t, r)
 	assert.Equal(t, driverPod.UID, r.UID)
@@ -73,7 +73,7 @@ func TestMutateExecutorPod(t *testing.T) {
 		SparkRoleLabel: SparkRoleExecutorValue,
 	}
 	req := getAdmissionRequest(t, execPod)
-	r, err := MutatePod(&util.FakeStorageProvider{}, log, req)
+	r, err := NewPodMutator(log, &util.FakeStorageProvider{}).Mutate(req)
 	assert.NoError(t, err)
 	assert.NotNil(t, r)
 	assert.Equal(t, execPod.UID, r.UID)
@@ -96,22 +96,23 @@ func TestIdempotency(t *testing.T) {
 		SparkRoleLabel: SparkRoleDriverValue,
 	}
 	req := getAdmissionRequest(t, driverPod)
-	r, err := MutatePod(&util.FakeStorageProvider{}, log, req)
+	m := NewPodMutator(log, &util.FakeStorageProvider{})
+	r, err := m.Mutate(req)
 	require.NoError(t, err)
 
 	obj, err := ApplyJsonPatch(r.Patch, driverPod)
 	require.NoError(t, err)
-	newPod, ok := obj.(*(corev1.Pod))
+	newPod, ok := obj.(*corev1.Pod)
 	require.True(t, ok)
 
 	req = getAdmissionRequest(t, newPod)
-	r, err = MutatePod(&util.FakeStorageProvider{}, log, req)
+	r, err = m.Mutate(req)
 	assert.NoError(t, err)
 	assert.Equal(t, "[]", string(r.Patch))
 
 	obj2, err := ApplyJsonPatch(r.Patch, newPod)
 	assert.NoError(t, err)
-	pod2, ok := obj2.(*(corev1.Pod))
+	pod2, ok := obj2.(*corev1.Pod)
 	require.True(t, ok)
 
 	assert.Equal(t, 2, len(pod2.Spec.Containers))
@@ -122,7 +123,7 @@ func TestIdempotency(t *testing.T) {
 
 func TestSkipNonSparkPod(t *testing.T) {
 	req := getAdmissionRequest(t, simplePod)
-	r, err := MutatePod(&util.FailedStorageProvider{}, log, req)
+	r, err := NewPodMutator(log, &util.FailedStorageProvider{}).Mutate(req)
 	assert.NoError(t, err)
 	assert.NotNil(t, r)
 	assert.Equal(t, simplePod.UID, r.UID)
@@ -137,7 +138,8 @@ func TestMutatePodBadStorage(t *testing.T) {
 		SparkRoleLabel: SparkRoleDriverValue,
 	}
 	req := getAdmissionRequest(t, driverPod)
-	r, err := MutatePod(&util.FailedStorageProvider{}, log, req)
+	m := NewPodMutator(log, &util.FailedStorageProvider{})
+	r, err := m.Mutate(req)
 	assert.NoError(t, err)
 	assert.NotNil(t, r)
 	assert.Equal(t, driverPod.UID, r.UID)
@@ -146,7 +148,7 @@ func TestMutatePodBadStorage(t *testing.T) {
 	assert.True(t, r.Allowed)
 
 	req = getAdmissionRequest(t, driverPod)
-	r, err = MutatePod(&util.NilStorageProvider{}, log, req)
+	r, err = m.Mutate(req)
 	assert.NoError(t, err)
 	assert.NotNil(t, r)
 	assert.Equal(t, driverPod.UID, r.UID)

--- a/admission/server.go
+++ b/admission/server.go
@@ -21,7 +21,9 @@ type AdmissionController struct {
 	log      logr.Logger
 }
 
-type Mutator func(storageInfo cloudstorage.CloudStorageProvider, log logr.Logger, admissionSpec *admissionv1.AdmissionRequest) (*admissionv1.AdmissionResponse, error)
+type Mutator interface {
+	Mutate(admissionSpec *admissionv1.AdmissionRequest) (*admissionv1.AdmissionResponse, error)
+}
 
 func handleRoot(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintf(w, "Wave Mutating Admission Webhook")
@@ -34,7 +36,7 @@ func NewAdmissionController(provider cloudstorage.CloudStorageProvider, log logr
 	}
 }
 
-func (ac *AdmissionController) GetHandlerFunc(mutate Mutator) func(http.ResponseWriter, *http.Request) {
+func (ac *AdmissionController) GetHandlerFunc(m Mutator) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		body, err := ioutil.ReadAll(r.Body)
 		defer r.Body.Close()
@@ -52,7 +54,7 @@ func (ac *AdmissionController) GetHandlerFunc(mutate Mutator) func(http.Response
 			return
 		}
 
-		response, err := mutate(ac.provider, ac.log, review.Request)
+		response, err := m.Mutate(review.Request)
 		if err != nil {
 			ac.log.Error(err, "mutating webhook request", "name", review.Request.Name, "kind", review.Request.Kind)
 			w.WriteHeader(http.StatusInternalServerError)
@@ -74,7 +76,8 @@ func (ac *AdmissionController) Start(ctx context.Context) error {
 	var err error
 
 	var conf *tls.Config = nil
-	certDir := "/etc/webhook/certs"
+	// TODO: Remove telepresence variable check, looks out of place
+	certDir := fmt.Sprintf("%s/etc/webhook/certs", os.Getenv("TELEPRESENCE_ROOT"))
 	fileinfo, err := os.Stat(certDir)
 	if err != nil {
 		return err
@@ -86,10 +89,14 @@ func (ac *AdmissionController) Start(ctx context.Context) error {
 			Certificates: []tls.Certificate{cert},
 		}
 	}
+
+	pm := NewPodMutator(ac.log, ac.provider)
+	cm := NewConfigMapMutator(ac.log, ac.provider)
+
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", handleRoot)
-	mux.HandleFunc("/mutate/pod", ac.GetHandlerFunc(MutatePod))
-	mux.HandleFunc("/mutate/configmap", ac.GetHandlerFunc(MutateConfigMap))
+	mux.HandleFunc("/mutate/pod", ac.GetHandlerFunc(pm))
+	mux.HandleFunc("/mutate/configmap", ac.GetHandlerFunc(cm))
 
 	srv := &http.Server{
 		Addr:      "0.0.0.0:9443", // TODO configure port


### PR DESCRIPTION
Two types implement the new Mutator interface
* ConfigMapMutator
* PodMutator

The admission server really only make sure to propagate the admission
request into the correct mutator.

This gives us the ability to add more functionality into the mutators
themselves without having to mess with the Mutate function