### PR TITLE
[BGD-693] Kill storage sync even on success

### DIFF
--- a/admission/pods.go
+++ b/admission/pods.go
@@ -135,7 +135,7 @@ func (m PodMutator) mutateDriverPod(sourceObj *corev1.Pod, storageInfo *cloudsto
 
 	webServerPort := strconv.Itoa(int(storagesync.Port))
 	storageContainer := corev1.Container{
-		Name:            storagesync.ContainerName,
+		Name:            storagesync.SyncContainerName,
 		Image:           "public.ecr.aws/l8m2k1n1/netapp/cloud-storage-sync:v0.4.0",
 		ImagePullPolicy: corev1.PullIfNotPresent,
 		Command:         []string{"/tini"},

--- a/internal/storagesync/storagesync.go
+++ b/internal/storagesync/storagesync.go
@@ -13,38 +13,48 @@ import (
 )
 
 const (
-	Port          int32  = 23174
-	ContainerName string = "storage-sync"
-	syncTimeout          = 1 * time.Minute
+	Port               int32  = 23174
+	SyncContainerName  string = "storage-sync"
+	syncTimeoutError          = 1 * time.Minute
+	syncTimeoutSuccess        = 10 * time.Minute
 )
 
 func ShouldStopSync(pod *corev1.Pod) bool {
 
 	var storageSyncRunning bool
+	var driverTerminated bool
+	var driverTerminationTime metav1.Time
 	var driverFailed bool
-	var driverFailureTime metav1.Time
 
 	for _, containerStatus := range pod.Status.ContainerStatuses {
 		switch containerStatus.Name {
-		case ContainerName:
+		case SyncContainerName:
 			if containerStatus.State.Running != nil {
 				storageSyncRunning = true
 			}
 		case sparkapi.SparkDriverContainerName:
 			if containerStatus.State.Terminated != nil {
+				driverTerminated = true
+				driverTerminationTime = containerStatus.State.Terminated.FinishedAt
 				if containerStatus.State.Terminated.ExitCode != 0 {
 					driverFailed = true
-					driverFailureTime = containerStatus.State.Terminated.FinishedAt
 				}
 			}
 		}
 	}
 
-	if storageSyncRunning && driverFailed {
+	if storageSyncRunning && driverTerminated {
 		// Let's allow the storage sync container a bit of time
 		// before we tell it to stop, in case it is able to finish on its own
 		currentTime := time.Now().Unix()
-		timeoutTime := driverFailureTime.Add(syncTimeout).Unix()
+
+		var timeoutTime int64
+		if driverFailed {
+			timeoutTime = driverTerminationTime.Add(syncTimeoutError).Unix()
+		} else {
+			timeoutTime = driverTerminationTime.Add(syncTimeoutSuccess).Unix()
+		}
+
 		if currentTime >= timeoutTime {
 			return true
 		}

--- a/internal/storagesync/storagesync.go
+++ b/internal/storagesync/storagesync.go
@@ -16,10 +16,14 @@ const (
 	Port              int32  = 23174
 	SyncContainerName string = "storage-sync"
 
+	// syncTimeout specifies how long we wait after driver termination
+	// before we tell the storage sync container to stop.
 	// Note that an in-progress sync operation will not be terminated
-	// even if we tell the storage sync container to stop
-	syncTimeoutError   = 1 * time.Minute
-	syncTimeoutSuccess = 5 * time.Minute
+	// even if we tell the storage sync container to stop, so this value
+	// specifies how long we should wait for event logs to appear and the sync to start,
+	// and in the case of repeated sync failures, how long we should wait before
+	// giving up.
+	syncTimeout = 3 * time.Minute
 )
 
 func ShouldStopSync(pod *corev1.Pod) bool {
@@ -27,7 +31,6 @@ func ShouldStopSync(pod *corev1.Pod) bool {
 	var storageSyncRunning bool
 	var driverTerminated bool
 	var driverTerminationTime metav1.Time
-	var driverFailed bool
 
 	for _, containerStatus := range pod.Status.ContainerStatuses {
 		switch containerStatus.Name {
@@ -39,9 +42,6 @@ func ShouldStopSync(pod *corev1.Pod) bool {
 			if containerStatus.State.Terminated != nil {
 				driverTerminated = true
 				driverTerminationTime = containerStatus.State.Terminated.FinishedAt
-				if containerStatus.State.Terminated.ExitCode != 0 {
-					driverFailed = true
-				}
 			}
 		}
 	}
@@ -50,14 +50,7 @@ func ShouldStopSync(pod *corev1.Pod) bool {
 		// Let's allow the storage sync container a bit of time
 		// before we tell it to stop, in case it is able to finish on its own
 		currentTime := time.Now().Unix()
-
-		var timeoutTime int64
-		if driverFailed {
-			timeoutTime = driverTerminationTime.Add(syncTimeoutError).Unix()
-		} else {
-			timeoutTime = driverTerminationTime.Add(syncTimeoutSuccess).Unix()
-		}
-
+		timeoutTime := driverTerminationTime.Add(syncTimeout).Unix()
 		if currentTime >= timeoutTime {
 			return true
 		}

--- a/internal/storagesync/storagesync.go
+++ b/internal/storagesync/storagesync.go
@@ -13,10 +13,13 @@ import (
 )
 
 const (
-	Port               int32  = 23174
-	SyncContainerName  string = "storage-sync"
-	syncTimeoutError          = 1 * time.Minute
-	syncTimeoutSuccess        = 10 * time.Minute
+	Port              int32  = 23174
+	SyncContainerName string = "storage-sync"
+
+	// Note that an in-progress sync operation will not be terminated
+	// even if we tell the storage sync container to stop
+	syncTimeoutError   = 1 * time.Minute
+	syncTimeoutSuccess = 5 * time.Minute
 )
 
 func ShouldStopSync(pod *corev1.Pod) bool {

--- a/internal/storagesync/storagesync_test.go
+++ b/internal/storagesync/storagesync_test.go
@@ -1,0 +1,163 @@
+package storagesync
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/spotinst/wave-operator/internal/sparkapi"
+)
+
+func TestShouldStopSync(t *testing.T) {
+
+	t.Run("whenDriverRunning_storageSyncRunning_shouldNotStopSync", func(tt *testing.T) {
+
+		containerStatuses := []corev1.ContainerStatus{
+			getRunningContainerStatus(SyncContainerName),
+			getRunningContainerStatus(sparkapi.SparkDriverContainerName),
+		}
+
+		pod := getTestPod(containerStatuses)
+		res := ShouldStopSync(pod)
+		assert.False(tt, res)
+
+	})
+
+	t.Run("whenDriverRunning_storageSyncNotRunning_shouldNotStopSync", func(tt *testing.T) {
+
+		containerStatuses := []corev1.ContainerStatus{
+			getTerminatedContainerStatus(SyncContainerName, 0, time.Now()),
+			getRunningContainerStatus(sparkapi.SparkDriverContainerName),
+		}
+
+		pod := getTestPod(containerStatuses)
+		res := ShouldStopSync(pod)
+		assert.False(tt, res)
+
+	})
+
+	t.Run("whenDriverNotRunning_storageSyncRunning_driverFailed_timeoutNotPassed_shouldNotStopSync", func(tt *testing.T) {
+
+		containerStatuses := []corev1.ContainerStatus{
+			getRunningContainerStatus(SyncContainerName),
+			getTerminatedContainerStatus(sparkapi.SparkDriverContainerName, 1, time.Now()),
+		}
+
+		pod := getTestPod(containerStatuses)
+		res := ShouldStopSync(pod)
+		assert.False(tt, res)
+
+	})
+
+	t.Run("whenDriverNotRunning_storageSyncRunning_driverFailed_timeoutPassed_shouldStopSync", func(tt *testing.T) {
+
+		containerStatuses := []corev1.ContainerStatus{
+			getRunningContainerStatus(SyncContainerName),
+			getTerminatedContainerStatus(sparkapi.SparkDriverContainerName, 1, time.Now().Add(-syncTimeoutError)),
+		}
+
+		pod := getTestPod(containerStatuses)
+		res := ShouldStopSync(pod)
+		assert.True(tt, res)
+
+	})
+
+	t.Run("whenDriverNotRunning_storageSyncRunning_driverSucceeded_timeoutNotPassed_shouldNotStopSync", func(tt *testing.T) {
+
+		containerStatuses := []corev1.ContainerStatus{
+			getRunningContainerStatus(SyncContainerName),
+			getTerminatedContainerStatus(sparkapi.SparkDriverContainerName, 0, time.Now()),
+		}
+
+		pod := getTestPod(containerStatuses)
+		res := ShouldStopSync(pod)
+		assert.False(tt, res)
+
+	})
+
+	t.Run("whenDriverNotRunning_storageSyncRunning_driverSucceeded_timeoutPassed_shouldStopSync", func(tt *testing.T) {
+
+		containerStatuses := []corev1.ContainerStatus{
+			getRunningContainerStatus(SyncContainerName),
+			getTerminatedContainerStatus(sparkapi.SparkDriverContainerName, 0, time.Now().Add(-syncTimeoutSuccess)),
+		}
+
+		pod := getTestPod(containerStatuses)
+		res := ShouldStopSync(pod)
+		assert.True(tt, res)
+
+	})
+
+	t.Run("whenDriverWaiting_storageSyncRunning_shouldNotStopSync", func(tt *testing.T) {
+
+		containerStatuses := []corev1.ContainerStatus{
+			getRunningContainerStatus(SyncContainerName),
+			getWaitingContainerStatus(sparkapi.SparkDriverContainerName),
+		}
+
+		pod := getTestPod(containerStatuses)
+		res := ShouldStopSync(pod)
+		assert.False(tt, res)
+
+	})
+
+	t.Run("whenDriverNotRunning_storageSyncNotRunning_driverFailed_timeoutPassed_shouldNotStopSync", func(tt *testing.T) {
+
+		containerStatuses := []corev1.ContainerStatus{
+			getTerminatedContainerStatus(SyncContainerName, 0, time.Now()),
+			getTerminatedContainerStatus(sparkapi.SparkDriverContainerName, 1, time.Now().Add(-syncTimeoutError)),
+		}
+
+		pod := getTestPod(containerStatuses)
+		res := ShouldStopSync(pod)
+		assert.False(tt, res)
+
+	})
+
+}
+
+func getRunningContainerStatus(containerName string) corev1.ContainerStatus {
+	return corev1.ContainerStatus{
+		Name: containerName,
+		State: corev1.ContainerState{
+			Running: &corev1.ContainerStateRunning{},
+		},
+	}
+}
+
+func getWaitingContainerStatus(containerName string) corev1.ContainerStatus {
+	return corev1.ContainerStatus{
+		Name: containerName,
+		State: corev1.ContainerState{
+			Waiting: &corev1.ContainerStateWaiting{},
+		},
+	}
+}
+
+func getTerminatedContainerStatus(containerName string, exitCode int, terminationTime time.Time) corev1.ContainerStatus {
+	return corev1.ContainerStatus{
+		Name: containerName,
+		State: corev1.ContainerState{
+			Terminated: &corev1.ContainerStateTerminated{
+				ExitCode: int32(exitCode),
+				FinishedAt: metav1.Time{
+					Time: terminationTime,
+				},
+			},
+		},
+	}
+}
+
+func getTestPod(containerStatuses []corev1.ContainerStatus) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "testPod",
+		},
+		Status: corev1.PodStatus{
+			ContainerStatuses: containerStatuses,
+		},
+	}
+}


### PR DESCRIPTION
Makes sure the storage sync sidecar is killed eventually even if the application finishes successfully.