### PR TITLE
[BGD-805] CM mutation fix

### DIFF
--- a/admission/configmaps.go
+++ b/admission/configmaps.go
@@ -3,7 +3,6 @@ package admission
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/go-logr/logr"
 	"github.com/magiconair/properties"
@@ -49,18 +48,10 @@ func (m ConfigMapMutator) Mutate(req *admissionv1.AdmissionRequest) (*admissionv
 		Allowed: true,
 	}
 
-	// check to make sure it's a spark configmap
-	// "[namespace]-[spark-id]-driver-conf-map."
-	if !strings.HasSuffix(sourceObj.Name, "-driver-conf-map") {
-		return resp, nil
-	}
-	// XX don't check this. for spark-operator, no namespace prefix
-	// if !strings.HasPrefix(sourceObj.Name, sourceObj.Namespace) {
-	// 	return resp, nil
-	// }
 	if len(sourceObj.ObjectMeta.OwnerReferences) == 0 {
 		return resp, nil
 	}
+
 	if sourceObj.Data["spark.properties"] == "" {
 		return resp, nil
 	}
@@ -72,7 +63,12 @@ func (m ConfigMapMutator) Mutate(req *admissionv1.AdmissionRequest) (*admissionv
 	}
 
 	log.Info("Got config map owner pod",
-		"name", ownerPod.Name, "namespace", ownerPod.Namespace, "annotations", ownerPod.Annotations)
+		"name", ownerPod.Name, "namespace", ownerPod.Namespace, "labels", ownerPod.Labels, "annotations", ownerPod.Annotations)
+
+	if ownerPod.Labels[SparkRoleLabel] != SparkRoleDriverValue {
+		log.Info("Not a driver config map, will not mutate config map")
+		return resp, nil
+	}
 
 	if !config.IsEventLogSyncEnabled(ownerPod.Annotations) {
 		log.Info("Event log sync not enabled, will not mutate config map")
@@ -95,7 +91,7 @@ func (m ConfigMapMutator) Mutate(req *admissionv1.AdmissionRequest) (*admissionv
 	propertyString := modObj.Data["spark.properties"]
 	props, err := properties.LoadString(propertyString)
 	if err != nil {
-		log.Error(err, "unparseable spark property data in configmap")
+		log.Error(err, "un-parsable spark property data in configmap")
 		return resp, nil
 	}
 	if props == nil {

--- a/admission/configmaps_test.go
+++ b/admission/configmaps_test.go
@@ -126,6 +126,43 @@ func TestMutateNonSparkCM(t *testing.T) {
 	assert.True(t, r.Allowed)
 }
 
+func TestMutateNonSparkDriverCM(t *testing.T) {
+
+	cm := sparkConfigMap
+
+	testFunc := func(ownerPod *corev1.Pod) {
+		clientSet := k8sfake.NewSimpleClientset(ownerPod)
+		req := getAdmissionRequest(t, cm)
+		r, err := NewConfigMapMutator(log, clientSet, &util.FakeStorageProvider{}).Mutate(req)
+		assert.NoError(t, err)
+		assert.NotNil(t, r)
+		assert.Equal(t, cm.UID, r.UID)
+		assert.Nil(t, r.PatchType)
+		assert.Nil(t, r.Patch)
+		assert.True(t, r.Allowed)
+
+	}
+
+	t.Run("whenExecutorOwnerPod", func(tt *testing.T) {
+		ownerPod := getDriverPod(cm.OwnerReferences[0].Name, cm.Namespace, true, "")
+		ownerPod.Labels[SparkRoleLabel] = SparkRoleExecutorValue
+		testFunc(ownerPod)
+	})
+
+	t.Run("whenNotSparkOwnerPod", func(tt *testing.T) {
+		ownerPod := getDriverPod(cm.OwnerReferences[0].Name, cm.Namespace, true, "")
+		delete(ownerPod.Labels, SparkRoleLabel)
+		testFunc(ownerPod)
+	})
+
+	t.Run("whenOwnerPodLabelsNil", func(tt *testing.T) {
+		ownerPod := getDriverPod(cm.OwnerReferences[0].Name, cm.Namespace, true, "")
+		ownerPod.Labels = nil
+		testFunc(ownerPod)
+	})
+
+}
+
 func TestMutateBadSparkCM(t *testing.T) {
 	cm := badSparkConfigMap
 	driver := getDriverPod(cm.OwnerReferences[0].Name, cm.Namespace, true, "")


### PR DESCRIPTION
We were incorrectly relying on config map names in the config map mutating admission webhook. Now we check the labels on the owner pod instead.