### PR TITLE
Increasing the timeout and sleeps for the timeout test

### DIFF
--- a/internal/sparkapi/client/transport/http_test.go
+++ b/internal/sparkapi/client/transport/http_test.go
@@ -75,8 +75,8 @@ func TestHttpClientGet(t *testing.T) {
 		assert.ErrorAs(tt, err, &ServiceUnavailableError{})
 	})
 	t.Run("ReturnsServiceUnavailableOnTimeout", func(tt *testing.T) {
-		t := NewHTTPClientTransport(host, port, WithTimeout(1*time.Microsecond), WithTransport(transportTestFunc(func(req *http.Request) (*http.Response, error) {
-			time.Sleep(5 * time.Microsecond)
+		t := NewHTTPClientTransport(host, port, WithTimeout(50*time.Millisecond), WithTransport(transportTestFunc(func(req *http.Request) (*http.Response, error) {
+			time.Sleep(100 * time.Millisecond)
 			return nil, nil
 		})))
 


### PR DESCRIPTION
Changing this from a single microsecond into miliseconds to
try to remove the flakyness of this particular testcase